### PR TITLE
Drop lodash in favor of the bitcore-bundled one

### DIFF
--- a/lib/insight.js
+++ b/lib/insight.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _ = require('lodash');
+var _ = require('bitcore').deps._;
 var request = require('request');
 
 var bitcore = require('bitcore');

--- a/package.json
+++ b/package.json
@@ -41,9 +41,8 @@
     "sinon": "^1.12.2"
   },
   "dependencies": {
-    "bitcore": "^0.9.0",
+    "bitcore": "^0.9.6",
     "browser-request": "^0.3.3",
-    "lodash": "^2.4.1",
     "request": "^2.51.0"
   }
 }


### PR DESCRIPTION
Blocked on bitcore's next release (0.9.6)
