### PR TITLE
Fix for same modules being loaded

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "request": "^2.51.0"
   },
   "peerDependencies": {
-    "bitcore-lib": "^0.13.14",
+    "bitcore-lib": "^0.13.14"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,8 +37,10 @@
     "sinon": "^1.12.2"
   },
   "dependencies": {
-    "bitcore-lib": "^0.13.14",
     "browser-request": "^0.3.3",
     "request": "^2.51.0"
+  },
+  "peerDependencies": {
+    "bitcore-lib": "^0.13.14",
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "request": "^2.51.0"
   },
   "peerDependencies": {
-    "bitcore-lib": "^0.13.14"
+    "bitcore-lib": ">=0.13.14"
   }
 }


### PR DESCRIPTION

```Error: More than one instance of bitcore-lib found. Please make sure to require bitcore-lib and check that submodules do not also include their own bitcore-lib dependency.```

same modules are being loaded to stop this, I made bitcore-lib as a peer dependency and the problem is removed
