### PR TITLE
Fix self-hosted insight not resolving

### DIFF
--- a/lib/insight.js
+++ b/lib/insight.js
@@ -25,6 +25,7 @@ function Insight(url, network) {
   if (!url && !network) {
     return new Insight(Networks.defaultNetwork);
   }
+  let usingBitpay = false;
   if (Networks.get(url)) {
     network = Networks.get(url);
     if (network === Networks.livenet) {
@@ -32,10 +33,12 @@ function Insight(url, network) {
     } else {
       url = 'https://test-insight.bitpay.com';
     }
+    usingBitpay = true;
   }
   JSUtil.defineImmutable(this, {
     url: url,
-    network: Networks.get(network) || Networks.defaultNetwork
+    network: Networks.get(network) || Networks.defaultNetwork,
+    api: usingBitpay ? '/api' : '/insight-api' // insight api on bitcored is currently resolving to /insight-api/
   });
   this.request = request;
   return this;
@@ -57,7 +60,7 @@ Insight.prototype.getTransaction = function(txid, callback) {
   $.checkArgument(_.isString(txid));
   $.checkArgument(txid.length === 64);
 
-  this.requestGet('/api/tx/' + txid, function(err, res, body) {
+  this.requestGet(`/tx/${txid}`, function(err, res, body) {
     if (err || res.statusCode !== 200) {
       return callback(err || res);
     }
@@ -87,7 +90,7 @@ Insight.prototype.getUtxos = function(addresses, callback) {
     return new Address(address);
   });
 
-  this.requestPost('/api/addrs/utxo', {
+  this.requestPost('/addrs/utxo', {
     addrs: _.map(addresses, function(address) {
       return address.toString();
     }).join(',')
@@ -125,7 +128,7 @@ Insight.prototype.broadcast = function(transaction, callback) {
     transaction = transaction.serialize();
   }
 
-  this.requestPost('/api/tx/send', {
+  this.requestPost('/tx/send', {
     rawtx: transaction
   }, function(err, res, body) {
     if (err || res.statusCode !== 200) {
@@ -150,7 +153,7 @@ Insight.prototype.address = function(address, callback) {
   $.checkArgument(_.isFunction(callback));
   address = new Address(address);
 
-  this.requestGet('/api/addr/' + address.toString(), function(err, res, body) {
+  this.requestGet(`/addr/${address}`, function(err, res, body) {
     if (err || res.statusCode !== 200) {
       return callback(err || body);
     }
@@ -179,7 +182,7 @@ Insight.prototype.requestPost = function(path, data, callback) {
   $.checkArgument(_.isFunction(callback));
   this.request({
     method: 'POST',
-    url: this.url + path,
+    url: this.url + this.api + path,
     json: data
   }, callback);
 };
@@ -195,8 +198,9 @@ Insight.prototype.requestGet = function(path, callback) {
   $.checkArgument(_.isFunction(callback));
   this.request({
     method: 'GET',
-    url: this.url + path
+    url: this.url + this.api + path
   }, callback);
 };
+
 
 module.exports = Insight;

--- a/lib/insight.js
+++ b/lib/insight.js
@@ -21,11 +21,10 @@ var AddressInfo = require('./models/addressinfo');
  * @param {Network=} network whether to use livenet or testnet
  * @constructor
  */
-function Insight(url, network) {
+function Insight(url, network, api) {
   if (!url && !network) {
     return new Insight(Networks.defaultNetwork);
   }
-  let usingBitpay = false;
   if (Networks.get(url)) {
     network = Networks.get(url);
     if (network === Networks.livenet) {
@@ -33,12 +32,11 @@ function Insight(url, network) {
     } else {
       url = 'https://test-insight.bitpay.com';
     }
-    usingBitpay = true;
   }
   JSUtil.defineImmutable(this, {
     url: url,
     network: Networks.get(network) || Networks.defaultNetwork,
-    api: usingBitpay ? '/api' : '/insight-api' // insight api on bitcored is currently resolving to /insight-api/
+    api: api || '/api'
   });
   this.request = request;
   return this;


### PR DESCRIPTION
Self-hosting insight would not work, as `Insight` requests `/api/` and the self-hosted instance on `bitcored` would respond to `/insight-api/`.